### PR TITLE
Pin dependencies to resolve breaking changes in `wikipedia-api`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
-wikipedia_for_humans>=0.2.3
+wikipedia_for_humans~=0.2.3
 ovos_utils~=0.0.28
 neon-utils~=1.0
+
+# TODO: Below patching breaking API change in 0.6.0
+wikipedia-api~=0.5.8

--- a/skill.json
+++ b/skill.json
@@ -21,7 +21,8 @@
         "python": [
             "neon-utils~=1.0",
             "ovos_utils~=0.0.28",
-            "wikipedia_for_humans>=0.2.3"
+            "wikipedia-api~=0.5.8",
+            "wikipedia_for_humans~=0.2.3"
         ],
         "system": {},
         "skill": []


### PR DESCRIPTION
# Description
Pins `wikipedia-for-humans` to avoid incompatible updates
Pins max `wikipedia-api` until `wikipedia-for-humans` can be updated to handle the new call signature(s)

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->